### PR TITLE
Sanitization bug

### DIFF
--- a/lib/interactive/interactive.dart
+++ b/lib/interactive/interactive.dart
@@ -69,7 +69,6 @@ class InteractiveShellPageComponent implements OnInit, OnDestroy {
         // It starts with <stdin> which DART's default sanitizer does not allow
         // The custom sanitizer should be implemented,
         // Yet for now <stdin> is simply removed
-        print(error);
         String sanitizedError = error.replaceFirst(new RegExp(r"<stdin>(:\d+(: )?)?"), '');
         allLines.add(new ShellLine(LineType.stderr, sanitizedError));
         scrollToBottom();

--- a/lib/interactive/interactive.dart
+++ b/lib/interactive/interactive.dart
@@ -59,18 +59,12 @@ class InteractiveShellPageComponent implements OnInit, OnDestroy {
       socket.on('shell output', (output) {
         if (showLoadingDialog) _showNewIntro();
         showLoadingDialog = false;
-        allLines.add(new ShellLine(LineType.stdout, output));
+        allLines.add(new ShellLine(LineType.stdout, simpleSanitize(output)));
         scrollToBottom();
       });
 
       socket.on('shell error', (error) {
-        // TODO
-        // When the raw error message is sent, it often is not printed as
-        // It starts with <stdin> which DART's default sanitizer does not allow
-        // The custom sanitizer should be implemented,
-        // Yet for now <stdin> is simply removed
-        String sanitizedError = error.replaceFirst(new RegExp(r"<stdin>(:\d+(: )?)?"), '');
-        allLines.add(new ShellLine(LineType.stderr, sanitizedError));
+        allLines.add(new ShellLine(LineType.stderr, simpleSanitize(error)));
         scrollToBottom();
       });
     });
@@ -78,7 +72,6 @@ class InteractiveShellPageComponent implements OnInit, OnDestroy {
 
   void onInputChange() {
     scrollToBottom();
-    print(shellInput.focused);
     if (!shellInput.focused) return;
 
     currentCmd += "\n" + shellInput.inputText;
@@ -133,5 +126,14 @@ class InteractiveShellPageComponent implements OnInit, OnDestroy {
           .add(new ShellLine(LineType.intro, starterTutorialDesc[introIndex]));
       introIndex++;
     }
+  }
+
+  // TODO
+  // When the raw (error) message is sent, it often is not printed as
+  // It starts with <stdin> which DART's default sanitizer does not allow
+  // The custom sanitizer should be implemented,
+  // Yet for now <stdin> is simply removed
+  String simpleSanitize(String msg) {
+    return msg.replaceFirst(new RegExp(r"<stdin>(:\d+(: )?)?"), '');
   }
 }

--- a/lib/interactive/interactive.dart
+++ b/lib/interactive/interactive.dart
@@ -64,7 +64,14 @@ class InteractiveShellPageComponent implements OnInit, OnDestroy {
       });
 
       socket.on('shell error', (error) {
-        allLines.add(new ShellLine(LineType.stderr, error));
+        // TODO
+        // When the raw error message is sent, it often is not printed as
+        // It starts with <stdin> which DART's default sanitizer does not allow
+        // The custom sanitizer should be implemented,
+        // Yet for now <stdin> is simply removed
+        print(error);
+        String sanitizedError = error.replaceFirst(new RegExp(r"<stdin>(:\d+(: )?)?"), '');
+        allLines.add(new ShellLine(LineType.stderr, sanitizedError));
         scrollToBottom();
       });
     });

--- a/lib/welcome/welcome.html
+++ b/lib/welcome/welcome.html
@@ -22,5 +22,4 @@
             <material-button [routerLink]="['Start']">Sign up / Sign in</material-button>
         </div>
     </div>
-    <div class="tl-footer"><a href="https://github.com/NickWu007">@NickWu007</a></div>
 </div>


### PR DESCRIPTION
Temporary fix of disallowing `<stdin>` in an error message. For now it removes three forms `<stdin> `may appear in the message. In time, we may want to implement a proper custom sanitizer.

Removed a link to Nick's GitHub repo.